### PR TITLE
fix: allow frankenphp; refactor code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `octane-health-check` will be documented in this file.
 
+## unreleased
+
+- fix `Class "Swoole\Process" not found` when using `frankenphp`
+- add `ApplicationServerEnum` to improve checks and messages
+- refactor `isApplicationServerRunning`
+- allow `setServer` method to receive a string or an `ApplicationServerEnum` instance 
+- show in messages/errors which application server is being used
+
 ## v2.0 - 2025-06-08
 
 Laravel 12 support (thanks https://github.com/devSviat)

--- a/src/ApplicationServerEnum.php
+++ b/src/ApplicationServerEnum.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ahtinurme;
+
+use Laravel\Octane\FrankenPhp\ServerProcessInspector as FrankenPhpServerProcessInspector;
+use Laravel\Octane\RoadRunner\ServerProcessInspector as RoadRunnerServerProcessInspector;
+use Laravel\Octane\Swoole\ServerProcessInspector as SwooleServerProcessInspector;
+
+enum ApplicationServerEnum: string
+{
+    case Swoole = 'swoole';
+    case RoadRunner = 'roadrunner';
+    case FrankenPhp = 'frankenphp';
+
+    /**
+     * Return a comma separated list of valid application server values.
+     */
+    public static function validValueList(): string
+    {
+        return collect(self::cases())
+            ->map(fn (self $value) => $value->value)
+            ->implode(', ');
+    }
+
+    public function description(): string
+    {
+        return match ($this) {
+            self::Swoole => 'Swoole',
+            self::RoadRunner => 'RoadRunner',
+            self::FrankenPhp => 'FrankenPHP',
+        };
+    }
+
+    public function processInspectorClassname(): string
+    {
+        return match ($this) {
+            self::Swoole => SwooleServerProcessInspector::class,
+            self::RoadRunner => RoadRunnerServerProcessInspector::class,
+            self::FrankenPhp => FrankenPhpServerProcessInspector::class,
+        };
+    }
+}

--- a/tests/OctaneCheckTest.php
+++ b/tests/OctaneCheckTest.php
@@ -1,12 +1,42 @@
 <?php
 
+use Ahtinurme\ApplicationServerEnum;
 use Ahtinurme\OctaneCheck;
 use Spatie\Health\Enums\Status;
+
+function invalidServerNameHelper(string $server, bool $prefixWithGenericError = false): string
+{
+    if ($server === '') {
+        $server = "''";
+    }
+
+    $genericError = $prefixWithGenericError ?
+        'Octane does not seem to be installed correctly: ' :
+        '';
+
+    return "$genericError$server is not a valid application server name. Please use one of these values: ".
+        ApplicationServerEnum::validValueList();
+}
+
+test('setName throws an exception when using an invalid application server name', function () {
+    $invalidServerName = 'invalid';
+
+    expect(ApplicationServerEnum::tryFrom($invalidServerName))
+        ->toBeNull()
+        ->and(
+            fn () => OctaneCheck::new()
+                ->setServer($invalidServerName)
+                ->run()
+        )->toThrow(
+            Exception::class,
+            invalidServerNameHelper($invalidServerName)
+        );
+});
 
 it('will fail when Octane is not installed', function () {
     $result = OctaneCheck::new()->run();
 
     expect($result)
         ->status->toBe(Status::failed())
-        ->notificationMessage->toBe('Octane does not seem to be installed correctly.');
+        ->notificationMessage->toBe(invalidServerNameHelper('', true));
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,1 +1,6 @@
 <?php
+
+use Ahtinurme\Tests\TestCase;
+
+uses(TestCase::class)
+    ->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ahtinurme\Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Orchestra\Testbench\Concerns\CreatesApplication;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}


### PR DESCRIPTION
This PR fixes https://github.com/ahtinurme/octane-health-check/issues/2 and adds some small improvements:

- add `ApplicationServerEnum` to improve checks and messages
- refactor `isApplicationServerRunning`
- allow `setServer` method to receive a string or an `ApplicationServerEnum` instance 
- show in messages/errors which application server is being used

I hope it helps. Thanks for your package!